### PR TITLE
Suite: Update new Home-Assistant GitHub repo locations.

### DIFF
--- a/package/opt/hassbian/helpers/info/version
+++ b/package/opt/hassbian/helpers/info/version
@@ -12,7 +12,7 @@ function hassbian.info.version.hassbian_config.installed {
 function hassbian.info.version.hassbian_config.remote {
   # Return the remote version of hassbian-config.
   local version
-  version=$(curl -sSL https://raw.githubusercontent.com/home-assistant/hassbian-scripts/dev/package/DEBIAN/control | \
+  version=$(curl -sSL https://raw.githubusercontent.com/Hassbian/hassbian-scripts/dev/package/DEBIAN/control | \
     grep Version | awk -F' ' '{print $NF}')
   printf "%s" "$version"
 }
@@ -36,7 +36,7 @@ function hassbian.info.version.homeassistant.github {
   # Return the latest version of homeassistant from github.
   local version
 
-  version=$(curl -s https://api.github.com/repos/home-assistant/home-assistant/releases | \
+  version=$(curl -s https://api.github.com/repos/home-assistant/core/releases | \
     grep tag_name | head -1 | awk -F'"' '{print $4}')
 
   printf "%s" "$version"
@@ -46,7 +46,7 @@ function hassbian.info.version.homeassistant.pypi {
   # Return the latest version of homeassistant from pypi.
   local version
 
-  version=$(curl -s https://api.github.com/repos/home-assistant/home-assistant/releases/latest | \
+  version=$(curl -s https://api.github.com/repos/home-assistant/core/releases/latest | \
       grep tag_name | awk -F'"' '{print $4}')
 
   printf "%s" "$version"


### PR DESCRIPTION
# Description

1. The `home-assistant` repo has been renamed to `core`.
2. The `hassbian-scripts` repo has moved Org.

## Checklist

<!-- 
Comment out the sections that does not apply like this comment.
For changes to documentation only, you can comment out all sections.


### New suite

- [ ] The code change is tested and works locally.
- [ ] The code is compliant with [Contributing guidelines][guidelines]
- [ ] Script has validation check of the job.
- [ ] Created documentation at `/docs/suites`
-->
### Change to existing suite

- [Y] The code change is tested and works locally.
- [Y] The code is compliant with [Contributing guidelines][guidelines]
- [NA] Updated documentation at `/docs/suites`

<!--
### New function

- [ ] The code change is tested and works locally.
- [ ] The code is compliant with [Contributing guidelines][guidelines]
- [ ] Script has validation check of the job.
- [ ] Created documentation at `/docs/cli`

### Change to existing function

- [ ] The code change is tested and works locally.
- [ ] The code is compliant with [Contributing guidelines][guidelines]
- [ ] Updated documentation at `/docs/cli`
-->
[guidelines]: https://github.com/home-assistant/hassbian-scripts/blob/master/.github/CONTRIBUTING.md